### PR TITLE
Move integration test db to port 5434

### DIFF
--- a/gws-core/pom.xml
+++ b/gws-core/pom.xml
@@ -605,7 +605,7 @@
                         </build>
                         <run>
                             <ports>
-                                <port>5433:5432</port>
+                                <port>5434:5432</port>
                             </ports>
                             <wait>
                                 <tcp>
@@ -622,6 +622,7 @@
                       <id>start-db</id>
                       <phase>pre-integration-test</phase>
                       <goals>
+                          <goal>stop</goal>
                           <goal>build</goal>
                           <goal>start</goal>
                       </goals>
@@ -630,6 +631,7 @@
                       <id>start-site-db</id>
                       <phase>pre-site</phase>
                       <goals>
+                          <goal>stop</goal>
                           <goal>build</goal>
                           <goal>start</goal>
                       </goals>

--- a/gws-core/src/test/resources/integration-test.properties
+++ b/gws-core/src/test/resources/integration-test.properties
@@ -1,3 +1,3 @@
-dbUrl=jdbc:postgresql://127.0.0.1:5433/geodesydb
+dbUrl=jdbc:postgresql://127.0.0.1:5434/geodesydb
 dbUsername=geodesy
 dbPassword=geodesypw


### PR DESCRIPTION
This way the integration test and system test databases can
on one host.