### PR TITLE
drop-old-responsible-party

### DIFF
--- a/gws-core/src/main/resources/db/drop-old-responsible-party-table.xml
+++ b/gws-core/src/main/resources/db/drop-old-responsible-party-table.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+   <changeSet author="hong (generated)" id="1482119825334-1">
+      <dropTable tableName="responsible_party"/>
+   </changeSet>
+   <changeSet author="hong (generated)" id="1482119825334-2">
+      <dropColumn columnName="site_contact_id" tableName="sitelog_site"/>
+   </changeSet>
+   <changeSet author="hong (generated)" id="1482119825334-3">
+      <dropColumn columnName="site_metadata_custodian_id" tableName="sitelog_site"/>
+   </changeSet>
+</databaseChangeLog>

--- a/gws-core/src/main/resources/db/geodesy-database-changelog.xml
+++ b/gws-core/src/main/resources/db/geodesy-database-changelog.xml
@@ -39,4 +39,5 @@
     <include file="db/add-comments-to-new-responsible-party-tables.xml"/>
     <include file="db/rename-responsible-party-column-name.sql"/>
     <include file="db/drop-non-null-constraint.xml"/>
+<include file="db/drop-old-responsible-party-table.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
responsible_party table was replaced by sitelog_responsible_party, so it can be dropped.
two columns, site_metadata_custodian_id and site_contact_id, in sitelog_site that are reference to old responsible_party can also be dropped