### PR TITLE
First run gws-webapp, then gws-geoserver

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,6 +32,7 @@ services:
                 - https_proxy
         image: gws/geoserver
         depends_on:
+            - web
             - db
             - tomcat
         ports:


### PR DESCRIPTION
Geoserver requires database objects that geodesy-web-services creates.