### PR TITLE
Respect the order of responsible parties

### DIFF
--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/SiteLog.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/SiteLog.java
@@ -17,6 +17,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
+import javax.persistence.OrderColumn;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.Transient;
@@ -142,6 +143,7 @@ public class SiteLog {
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @JoinColumn(name = "SITE_ID", referencedColumnName = "ID")
+    @OrderColumn(name = "INDEX")
     protected @Nullable List<SiteResponsibleParty> responsibleParties = new ArrayList<>();
 
     public @Nullable Integer getId() {

--- a/gws-core/src/main/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/ResponsiblePartiesMapper.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/ResponsiblePartiesMapper.java
@@ -44,15 +44,17 @@ public class ResponsiblePartiesMapper extends CustomMapper<SiteLogType, SiteLog>
         List<SiteResponsibleParty> siteResponsibleParties = siteLog.getResponsibleParties();
 
         addSiteResponsibleParty(siteResponsibleParties, siteLogType.getSiteOwner(), contactTypes.siteOwner());
-        addSiteResponsibleParty(siteResponsibleParties, siteLogType.getSiteMetadataCustodian(), contactTypes.siteMetadataCustodian());
-        addSiteResponsibleParty(siteResponsibleParties, siteLogType.getSiteDataSource(), contactTypes.siteDataSource());
 
         for (AgencyPropertyType agencyProperty : siteLogType.getSiteContacts()) {
             addSiteResponsibleParty(siteResponsibleParties, agencyProperty, contactTypes.siteContact());
+
         }
+        addSiteResponsibleParty(siteResponsibleParties, siteLogType.getSiteMetadataCustodian(), contactTypes.siteMetadataCustodian());
+
         for (AgencyPropertyType agencyProperty : siteLogType.getSiteDataCenters()) {
             addSiteResponsibleParty(siteResponsibleParties, agencyProperty, contactTypes.siteDataCenter());
         }
+        addSiteResponsibleParty(siteResponsibleParties, siteLogType.getSiteDataSource(), contactTypes.siteDataSource());
     }
 
     @Override

--- a/gws-core/src/main/resources/db/add-index-column-to-responsible-parties.xml
+++ b/gws-core/src/main/resources/db/add-index-column-to-responsible-parties.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+   <changeSet author="lbodor (generated)" id="1494977112808-1">
+      <addColumn tableName="sitelog_responsible_party">
+         <column name="index" type="int4"/>
+      </addColumn>
+   </changeSet>
+</databaseChangeLog>

--- a/gws-core/src/main/resources/db/geodesy-database-changelog.xml
+++ b/gws-core/src/main/resources/db/geodesy-database-changelog.xml
@@ -51,4 +51,5 @@
     <include file="db/add-missing-columns-to-problem-source-tables.xml"/>
     <include file="db/add-version-to-cors-network.xml"/>
     <include file="db/add-cors-network-name-constraints.xml"/>
+    <include file="db/add-index-column-to-responsible-parties.xml"/>
 </databaseChangeLog>

--- a/gws-core/src/test/java/au/gov/ga/geodesy/port/adapter/rest/UploadAliceGeodesyMLSiteLogRestITest.java
+++ b/gws-core/src/test/java/au/gov/ga/geodesy/port/adapter/rest/UploadAliceGeodesyMLSiteLogRestITest.java
@@ -6,7 +6,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
@@ -67,10 +70,12 @@ public class UploadAliceGeodesyMLSiteLogRestITest extends IntegrationTest {
             ;
     }
 
-    private void checkResponsiblePartyByType(SiteLog siteLog, ContactType contactType, List<String> individualNames) {
-        List<SiteResponsibleParty> parties = siteLog.getResponsiblePartiesByType(contactType);
+    private void checkResponsiblePartiesByType(SiteLog siteLog, ContactType contactType, List<String> individualNames) {
+        checkResponsibleParties(siteLog.getResponsiblePartiesByType(contactType), individualNames);
+    }
 
-        assertThat(parties.stream().map(p -> p.getParty().getIndividualName()).collect(Collectors.toList()),
+    private void checkResponsibleParties(List<SiteResponsibleParty> responsibleParties, List<String> individualNames) {
+        assertThat(responsibleParties.stream().map(p -> p.getParty().getIndividualName()).collect(Collectors.toList()),
             is(equalTo(individualNames)));
     }
 
@@ -78,14 +83,19 @@ public class UploadAliceGeodesyMLSiteLogRestITest extends IntegrationTest {
     public void checkResponsibleParties() throws Exception {
         SiteLog alice = siteLogs.findByFourCharacterId("ALIC");
 
-        List<SiteResponsibleParty> parties = alice.getResponsibleParties();
-        assertThat(parties.size(), is(7));
+        LinkedHashMap<ContactType, List<String>> expectedResponsibleParties = new LinkedHashMap<>();
+        expectedResponsibleParties.put(contactTypes.siteOwner(), Lists.newArrayList("Site Owner"));
+        expectedResponsibleParties.put(contactTypes.siteContact(), Lists.newArrayList("Site Contact 1", "Site Contact 2"));
+        expectedResponsibleParties.put(contactTypes.siteMetadataCustodian(), Lists.newArrayList("Site Metadata Custodian"));
+        expectedResponsibleParties.put(contactTypes.siteDataCenter(), Lists.newArrayList("Site Data Center 1", "Site Data Center 2"));
+        expectedResponsibleParties.put(contactTypes.siteDataSource(), Lists.newArrayList("Site Data Source"));
 
-        checkResponsiblePartyByType(alice, contactTypes.siteOwner(), Lists.newArrayList("Site Owner"));
-        checkResponsiblePartyByType(alice, contactTypes.siteContact(), Lists.newArrayList("Site Contact 1", "Site Contact 2"));
-        checkResponsiblePartyByType(alice, contactTypes.siteMetadataCustodian(), Lists.newArrayList("Site Metadata Custodian"));
-        checkResponsiblePartyByType(alice, contactTypes.siteDataCenter(), Lists.newArrayList("Site Data Center 1", "Site Data Center 2"));
-        checkResponsiblePartyByType(alice, contactTypes.siteDataSource(), Lists.newArrayList("Site Data Source"));
+        List<String> allIndividualNames = new ArrayList<>();
+        for (Entry<ContactType, List<String>> e : expectedResponsibleParties.entrySet()) {
+            checkResponsiblePartiesByType(alice, e.getKey(), e.getValue());
+            allIndividualNames.addAll(e.getValue());
+        }
+        checkResponsibleParties(alice.getResponsibleParties(), allIndividualNames);
     }
 
     // TODO: checkout uploaded site log, site, setups, equipment, and nodes


### PR DESCRIPTION
The order of responsible party types is defined in GeodesyML in `siteLog.xsd`.
The order of responsible party values is defined by the order in which
they appear in a given GeodesyML site log document.