### PR TITLE
Handle change tracking of log items

### DIFF
--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/equipment/EquipmentFactory.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/equipment/EquipmentFactory.java
@@ -10,7 +10,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import au.gov.ga.geodesy.domain.model.sitelog.CollocationInformation;
+import au.gov.ga.geodesy.domain.model.sitelog.CollocationInformationLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.EffectiveDates;
 import au.gov.ga.geodesy.domain.model.sitelog.EquipmentLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.FrequencyStandardLogItem;
@@ -135,7 +135,7 @@ public class EquipmentFactory {
         }
 
         @Override
-        public Pair<Equipment, EquipmentConfiguration> visit(CollocationInformation logItem) {
+        public Pair<Equipment, EquipmentConfiguration> visit(CollocationInformationLogItem logItem) {
             throw new UnsupportedOperationException();
         }
 

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/equipment/EquipmentFactory.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/equipment/EquipmentFactory.java
@@ -22,6 +22,7 @@ import au.gov.ga.geodesy.domain.model.sitelog.LogItemVisitor;
 import au.gov.ga.geodesy.domain.model.sitelog.OtherInstrumentationLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.PossibleProblemSourceLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.PressureSensorLogItem;
+import au.gov.ga.geodesy.domain.model.sitelog.SurveyedLocalTie;
 import au.gov.ga.geodesy.domain.model.sitelog.TemperatureSensorLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.WaterVaporSensorLogItem;
 import au.gov.ga.geodesy.exception.GeodesyRuntimeException;
@@ -136,6 +137,11 @@ public class EquipmentFactory {
 
         @Override
         public Pair<Equipment, EquipmentConfiguration> visit(CollocationInformationLogItem logItem) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Pair<Equipment, EquipmentConfiguration> visit(SurveyedLocalTie logItem) {
             throw new UnsupportedOperationException();
         }
 

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/equipment/EquipmentFactory.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/equipment/EquipmentFactory.java
@@ -10,6 +10,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import au.gov.ga.geodesy.domain.model.sitelog.CollocationInformation;
 import au.gov.ga.geodesy.domain.model.sitelog.EffectiveDates;
 import au.gov.ga.geodesy.domain.model.sitelog.EquipmentLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.FrequencyStandardLogItem;
@@ -130,6 +131,11 @@ public class EquipmentFactory {
 
         @Override
         public Pair<Equipment, EquipmentConfiguration> visit(LocalEpisodicEffectLogItem logItem) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Pair<Equipment, EquipmentConfiguration> visit(CollocationInformation logItem) {
             throw new UnsupportedOperationException();
         }
 

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/equipment/EquipmentFactory.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/equipment/EquipmentFactory.java
@@ -22,7 +22,7 @@ import au.gov.ga.geodesy.domain.model.sitelog.LogItemVisitor;
 import au.gov.ga.geodesy.domain.model.sitelog.OtherInstrumentationLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.PossibleProblemSourceLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.PressureSensorLogItem;
-import au.gov.ga.geodesy.domain.model.sitelog.SurveyedLocalTie;
+import au.gov.ga.geodesy.domain.model.sitelog.SurveyedLocalTieLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.TemperatureSensorLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.WaterVaporSensorLogItem;
 import au.gov.ga.geodesy.exception.GeodesyRuntimeException;
@@ -141,7 +141,7 @@ public class EquipmentFactory {
         }
 
         @Override
-        public Pair<Equipment, EquipmentConfiguration> visit(SurveyedLocalTie logItem) {
+        public Pair<Equipment, EquipmentConfiguration> visit(SurveyedLocalTieLogItem logItem) {
             throw new UnsupportedOperationException();
         }
 

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/CollocationInformation.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/CollocationInformation.java
@@ -15,7 +15,7 @@ import javax.validation.constraints.Size;
  */
 @Entity
 @Table(name = "SITELOG_COLLOCATIONINFORMATION")
-public class CollocationInformation {
+public class CollocationInformation implements LogItem {
 
     @Id
     @GeneratedValue(generator = "surrogateKeyGenerator")
@@ -102,5 +102,9 @@ public class CollocationInformation {
      */
     public void setNotes(String value) {
         this.notes = value;
+    }
+
+    public <T> T accept(LogItemVisitor<T> v) {
+        return v.visit(this);
     }
 }

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/CollocationInformationLogItem.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/CollocationInformationLogItem.java
@@ -15,7 +15,7 @@ import javax.validation.constraints.Size;
  */
 @Entity
 @Table(name = "SITELOG_COLLOCATIONINFORMATION")
-public class CollocationInformationLogItem implements LogItem {
+public class CollocationInformationLogItem extends LogItem {
 
     @Id
     @GeneratedValue(generator = "surrogateKeyGenerator")

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/CollocationInformationLogItem.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/CollocationInformationLogItem.java
@@ -15,7 +15,7 @@ import javax.validation.constraints.Size;
  */
 @Entity
 @Table(name = "SITELOG_COLLOCATIONINFORMATION")
-public class CollocationInformation implements LogItem {
+public class CollocationInformationLogItem implements LogItem {
 
     @Id
     @GeneratedValue(generator = "surrogateKeyGenerator")

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/EquipmentLogItem.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/EquipmentLogItem.java
@@ -1,7 +1,7 @@
 package au.gov.ga.geodesy.domain.model.sitelog;
 
-public interface EquipmentLogItem extends LogItem {
-    String getType();
-    String getSerialNumber();
+public abstract class EquipmentLogItem extends LogItem {
+    public abstract String getType();
+    public abstract String getSerialNumber();
 }
 

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/FrequencyStandardLogItem.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/FrequencyStandardLogItem.java
@@ -15,7 +15,7 @@ import javax.validation.constraints.Size;
  */
 @Entity
 @Table(name = "SITELOG_FREQUENCYSTANDARD")
-public class FrequencyStandardLogItem implements EquipmentLogItem {
+public class FrequencyStandardLogItem extends EquipmentLogItem {
 
     @Id
     @GeneratedValue(generator = "surrogateKeyGenerator")

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/GnssAntennaLogItem.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/GnssAntennaLogItem.java
@@ -16,7 +16,7 @@ import javax.validation.constraints.Size;
  */
 @Entity
 @Table(name = "SITELOG_GNSSANTENNA")
-public class GnssAntennaLogItem implements EquipmentLogItem {
+public class GnssAntennaLogItem extends EquipmentLogItem {
 
     @Id
     @GeneratedValue(generator = "surrogateKeyGenerator")

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/GnssReceiverLogItem.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/GnssReceiverLogItem.java
@@ -16,7 +16,7 @@ import javax.validation.constraints.Size;
  */
 @Entity
 @Table(name = "SITELOG_GNSSRECEIVER")
-public class GnssReceiverLogItem implements EquipmentLogItem {
+public class GnssReceiverLogItem extends EquipmentLogItem {
 
     @Id
     @GeneratedValue(generator = "surrogateKeyGenerator")

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/LocalEpisodicEffectLogItem.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/LocalEpisodicEffectLogItem.java
@@ -9,7 +9,7 @@ import javax.validation.constraints.Size;
  */
 @Entity
 @Table(name = "SITELOG_LOCALEPISODICEFFECT")
-public class LocalEpisodicEffectLogItem implements LogItem {
+public class LocalEpisodicEffectLogItem extends LogItem {
 
     @Id
     @GeneratedValue(generator = "surrogateKeyGenerator")

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/LogItem.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/LogItem.java
@@ -1,7 +1,54 @@
 package au.gov.ga.geodesy.domain.model.sitelog;
 
-public interface LogItem {
-    EffectiveDates getEffectiveDates();
-    <T> T accept(LogItemVisitor<T> v);
+import java.time.Instant;
+
+import javax.persistence.Column;
+import javax.persistence.MappedSuperclass;
+import javax.validation.constraints.Past;
+
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+
+@MappedSuperclass
+public abstract class LogItem {
+
+    @Past
+    @Column(name = "DATE_INSERTED")
+    protected Instant dateInserted;
+
+    @Past
+    @Column(name = "DATE_DELETED")
+    protected @MonotonicNonNull Instant dateDeleted;
+
+    @Past
+    @Column(name = "DELETED_REASON")
+    protected @MonotonicNonNull String deletedReason;
+
+    public abstract EffectiveDates getEffectiveDates();
+
+    public abstract <T> T accept(LogItemVisitor<T> v);
+
+    public Instant getDateInserted() {
+        return dateInserted;
+    }
+
+    public void setDateInserted(Instant dateInserted) {
+        this.dateInserted = dateInserted;
+    }
+
+    public Instant getDateDeleted() {
+        return dateDeleted;
+    }
+
+    public void setDateDeleted(Instant dateDeleted) {
+        this.dateDeleted = dateDeleted;
+    }
+
+    public String getDeletedReason() {
+        return deletedReason;
+    }
+
+    public void setDeletedReason(String deletedReason) {
+        this.deletedReason = deletedReason;
+    }
 }
 

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/LogItemVisitor.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/LogItemVisitor.java
@@ -12,6 +12,6 @@ public interface LogItemVisitor<T> {
     T visit(PossibleProblemSourceLogItem logItem);
     T visit(LocalEpisodicEffectLogItem logItem);
     T visit(CollocationInformationLogItem logItem);
-    T visit(SurveyedLocalTie logItem);
+    T visit(SurveyedLocalTieLogItem logItem);
 }
 

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/LogItemVisitor.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/LogItemVisitor.java
@@ -11,5 +11,6 @@ public interface LogItemVisitor<T> {
     T visit(OtherInstrumentationLogItem logItem);
     T visit(PossibleProblemSourceLogItem logItem);
     T visit(LocalEpisodicEffectLogItem logItem);
+    T visit(CollocationInformation logItem);
 }
 

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/LogItemVisitor.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/LogItemVisitor.java
@@ -11,6 +11,6 @@ public interface LogItemVisitor<T> {
     T visit(OtherInstrumentationLogItem logItem);
     T visit(PossibleProblemSourceLogItem logItem);
     T visit(LocalEpisodicEffectLogItem logItem);
-    T visit(CollocationInformation logItem);
+    T visit(CollocationInformationLogItem logItem);
 }
 

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/LogItemVisitor.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/LogItemVisitor.java
@@ -12,5 +12,6 @@ public interface LogItemVisitor<T> {
     T visit(PossibleProblemSourceLogItem logItem);
     T visit(LocalEpisodicEffectLogItem logItem);
     T visit(CollocationInformationLogItem logItem);
+    T visit(SurveyedLocalTie logItem);
 }
 

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/OtherInstrumentationLogItem.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/OtherInstrumentationLogItem.java
@@ -15,7 +15,7 @@ import javax.validation.constraints.Size;
  */
 @Entity
 @Table(name = "SITELOG_OTHERINSTRUMENTATION")
-public class OtherInstrumentationLogItem implements LogItem {
+public class OtherInstrumentationLogItem extends LogItem {
 
     @Id
     @GeneratedValue(generator = "surrogateKeyGenerator")

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/PossibleProblemSourceLogItem.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/PossibleProblemSourceLogItem.java
@@ -10,7 +10,7 @@ import javax.validation.constraints.Size;
  * http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/localInterferences/2004/baseLocalInterferencesLib.xsd:basePossibleProblemSourcesType
  */
 @MappedSuperclass
-public abstract class PossibleProblemSourceLogItem implements LogItem {
+public abstract class PossibleProblemSourceLogItem extends LogItem {
 
     @Size(max = 4000)
     @Column(name = "POSSIBLE_PROBLEM_SOURCE", length = 4000)

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/SensorEquipmentLogItem.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/SensorEquipmentLogItem.java
@@ -13,7 +13,7 @@ import javax.validation.constraints.Size;
  * http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2564/baseEquipmentLib.xsd:baseSensorEquipmentType"
  */
 @MappedSuperclass
-public abstract class SensorEquipmentLogItem implements EquipmentLogItem {
+public abstract class SensorEquipmentLogItem extends EquipmentLogItem {
 
     @Size(max = 256)
     @Column(name = "TYPE", length = 256)

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/SiteLog.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/SiteLog.java
@@ -80,7 +80,7 @@ public class SiteLog {
     @Valid
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @JoinColumn(name = "SITE_ID", referencedColumnName = "ID", foreignKey = @ForeignKey(name="FK_SITELOG_SITE_SITELOG_SURVEYEDLOCALTIE"))
-    protected Set<SurveyedLocalTie> surveyedLocalTies = new HashSet<>();
+    protected Set<SurveyedLocalTieLogItem> surveyedLocalTies = new HashSet<>();
 
     @Valid
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
@@ -250,14 +250,14 @@ public class SiteLog {
     /**
      * Return surveyed local ties.
      */
-    public Set<SurveyedLocalTie> getSurveyedLocalTies() {
+    public Set<SurveyedLocalTieLogItem> getSurveyedLocalTies() {
         return this.surveyedLocalTies;
     }
 
     /**
      * Set surveyed local ties.
      */
-    public void setSurveyedLocalTies(Set<SurveyedLocalTie> ties) {
+    public void setSurveyedLocalTies(Set<SurveyedLocalTieLogItem> ties) {
         surveyedLocalTies = ties;
     }
 

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/SiteLog.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/SiteLog.java
@@ -90,7 +90,7 @@ public class SiteLog {
     @Valid
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @JoinColumn(name = "SITE_ID", referencedColumnName = "ID", foreignKey = @ForeignKey(name="FK_SITELOG_SITE_SITELOG_COLLOCATIONINFORMATION"))
-    protected Set<CollocationInformation> collocationInformation = new HashSet<>();
+    protected Set<CollocationInformationLogItem> collocationInformation = new HashSet<>();
 
     @Valid
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
@@ -278,14 +278,14 @@ public class SiteLog {
     /**
      * Return collocation information.
      */
-    public Set<CollocationInformation> getCollocationInformation() {
+    public Set<CollocationInformationLogItem> getCollocationInformation() {
         return collocationInformation;
     }
 
     /**
      * Set collocation information.
      */
-    public void setCollocationInformation(Set<CollocationInformation> c) {
+    public void setCollocationInformation(Set<CollocationInformationLogItem> c) {
         collocationInformation = c;
     }
 

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/SurveyedLocalTie.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/SurveyedLocalTie.java
@@ -18,7 +18,7 @@ import javax.validation.constraints.Size;
  */
 @Entity
 @Table(name = "SITELOG_SURVEYEDLOCALTIE")
-public class SurveyedLocalTie {
+public class SurveyedLocalTie implements LogItem {
 
     @Id
     @GeneratedValue(generator = "surrogateKeyGenerator")
@@ -195,5 +195,13 @@ public class SurveyedLocalTie {
      */
     public void setNotes(String value) {
         this.notes = value;
+    }
+
+    public EffectiveDates getEffectiveDates() {
+        return new EffectiveDates(this.getDateMeasured(), this.getDateMeasured());
+    }
+
+    public <T> T accept(LogItemVisitor<T> v) {
+        return v.visit(this);
     }
 }

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/SurveyedLocalTieLogItem.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/SurveyedLocalTieLogItem.java
@@ -18,7 +18,7 @@ import javax.validation.constraints.Size;
  */
 @Entity
 @Table(name = "SITELOG_SURVEYEDLOCALTIE")
-public class SurveyedLocalTie implements LogItem {
+public class SurveyedLocalTieLogItem implements LogItem {
 
     @Id
     @GeneratedValue(generator = "surrogateKeyGenerator")

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/SurveyedLocalTieLogItem.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/sitelog/SurveyedLocalTieLogItem.java
@@ -18,7 +18,7 @@ import javax.validation.constraints.Size;
  */
 @Entity
 @Table(name = "SITELOG_SURVEYEDLOCALTIE")
-public class SurveyedLocalTieLogItem implements LogItem {
+public class SurveyedLocalTieLogItem extends LogItem {
 
     @Id
     @GeneratedValue(generator = "surrogateKeyGenerator")

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/service/CorsSiteService.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/service/CorsSiteService.java
@@ -7,6 +7,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
 
@@ -132,7 +133,12 @@ public class CorsSiteService implements EventSubscriber<SiteLogReceived> {
         Comparator<Instant> fromC = ComparatorUtils.nullLowComparator(ComparatorUtils.NATURAL_COMPARATOR);
         SortedSet<Instant> datesOfChange = new TreeSet<>(fromC);
 
-        for (EquipmentLogItem logItem : siteLog.getEquipmentLogItems()) {
+        List<EquipmentLogItem> equipmentLogItems = siteLog.getEquipmentLogItems()
+            .stream()
+            .filter(logItem -> logItem.getDateDeleted() == null)
+            .collect(Collectors.toList());
+
+        for (EquipmentLogItem logItem : equipmentLogItems) {
             EffectiveDates dates = logItem.getEffectiveDates();
             if (dates != null) {
                 if (dates.getFrom() != null) {
@@ -168,7 +174,7 @@ public class CorsSiteService implements EventSubscriber<SiteLogReceived> {
                 }
             }
         }
-        for (EquipmentLogItem logItem : siteLog.getEquipmentLogItems()) {
+        for (EquipmentLogItem logItem : equipmentLogItems) {
             addEquipment(logItem, setups);
         }
         return setups;

--- a/gws-core/src/main/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/CollocationInformationMapper.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/CollocationInformationMapper.java
@@ -1,6 +1,6 @@
 package au.gov.ga.geodesy.support.mapper.orika.geodesyml;
 
-import au.gov.ga.geodesy.domain.model.sitelog.CollocationInformation;
+import au.gov.ga.geodesy.domain.model.sitelog.CollocationInformationLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.EffectiveDates;
 import au.gov.ga.geodesy.support.java.util.Iso;
 import au.gov.xml.icsm.geodesyml.v_0_4.CollocationInformationType;
@@ -14,13 +14,13 @@ import net.opengis.gml.v_3_2_1.TimePeriodType;
  * Reversible mapping between GeodesyML CollocationInformationType DTO and
  * CollocationInformation site log entity.
  */
-public class CollocationInformationMapper implements Iso<CollocationInformationType, CollocationInformation> {
+public class CollocationInformationMapper implements Iso<CollocationInformationType, CollocationInformationLogItem> {
 
     private MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
     private MapperFacade mapper;
 
     public CollocationInformationMapper() {
-        mapperFactory.classMap(CollocationInformationType.class, CollocationInformation.class)
+        mapperFactory.classMap(CollocationInformationType.class, CollocationInformationLogItem.class)
                 .fieldMap("instrumentationType", "instrumentType").converter("instrumentTypeConverter").add()
                 .fieldMap("status", "status").converter("statusTypeConverter").add()
                 .fieldMap("validTime.abstractTimePrimitive", "effectiveDates").converter("jaxbElemConverter").add()
@@ -44,14 +44,14 @@ public class CollocationInformationMapper implements Iso<CollocationInformationT
     /**
      * {@inheritDoc}
      */
-    public CollocationInformation to(CollocationInformationType collocationInformationType) {
-        return mapper.map(collocationInformationType, CollocationInformation.class);
+    public CollocationInformationLogItem to(CollocationInformationType collocationInformationType) {
+        return mapper.map(collocationInformationType, CollocationInformationLogItem.class);
     }
 
     /**
      * {@inheritDoc}
      */
-    public CollocationInformationType from(CollocationInformation collocationInformation) {
+    public CollocationInformationType from(CollocationInformationLogItem collocationInformation) {
         return mapper.map(collocationInformation, CollocationInformationType.class);
     }
 }

--- a/gws-core/src/main/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/LogItemPropertyTypeMapper.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/LogItemPropertyTypeMapper.java
@@ -1,0 +1,47 @@
+package au.gov.ga.geodesy.support.mapper.orika.geodesyml;
+
+import au.gov.ga.geodesy.domain.model.sitelog.LogItem;
+import au.gov.ga.geodesy.support.gml.LogItemPropertyType;
+import au.gov.ga.geodesy.support.java.util.Iso;
+
+import ma.glasnost.orika.MapperFacade;
+import ma.glasnost.orika.MapperFactory;
+import ma.glasnost.orika.impl.DefaultMapperFactory;
+
+import net.opengis.gml.v_3_2_1.AbstractGMLType;
+
+/**
+ * Reversible mapping between a LogItemProperty type and its target element.
+ */
+public class LogItemPropertyTypeMapper<P extends LogItemPropertyType, T extends AbstractGMLType, L extends LogItem> implements Iso<P, L> {
+
+    private Iso<P, L> propertyToLogItemMapper;
+    private MapperFacade mapper;
+
+    public LogItemPropertyTypeMapper(Iso<T, L> logItemMapper) {
+        this.propertyToLogItemMapper = new GMLPropertyTypeMapper<P, T>().compose(logItemMapper);
+
+        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        mapperFactory.classMap(LogItemPropertyType.class, LogItem.class)
+            .field("dateInserted", "dateInserted")
+            .field("dateDeleted", "dateDeleted")
+            .field("deletedReason", "deletedReason")
+            .register();
+
+        mapperFactory.getConverterFactory().registerConverter(new InstantToTimePositionConverter());
+        this.mapper = mapperFactory.getMapperFacade();
+    }
+
+    public L to(P propertyType) {
+        L logItem = propertyToLogItemMapper.to(propertyType);
+        mapper.map(propertyType, logItem);
+        return logItem;
+    }
+
+    public P from(L logItem) {
+        P propertyType = propertyToLogItemMapper.from(logItem);
+        mapper.map(logItem, propertyType);
+        return propertyType;
+    }
+}
+

--- a/gws-core/src/main/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/SiteLogMapper.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/SiteLogMapper.java
@@ -23,7 +23,7 @@ import au.gov.ga.geodesy.domain.model.sitelog.SignalObstructionLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.SiteIdentification;
 import au.gov.ga.geodesy.domain.model.sitelog.SiteLocation;
 import au.gov.ga.geodesy.domain.model.sitelog.SiteLog;
-import au.gov.ga.geodesy.domain.model.sitelog.SurveyedLocalTie;
+import au.gov.ga.geodesy.domain.model.sitelog.SurveyedLocalTieLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.TemperatureSensorLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.WaterVaporSensorLogItem;
 import au.gov.ga.geodesy.support.gml.GMLPropertyType;
@@ -175,7 +175,7 @@ public class SiteLogMapper implements Iso<SiteLogType, SiteLog> {
         );
 
         converters.registerConverter("surveyedLocalTies",
-                new BidirectionalConverterWrapper<List<GMLPropertyType>, Set<SurveyedLocalTie>>(
+                new BidirectionalConverterWrapper<List<GMLPropertyType>, Set<SurveyedLocalTieLogItem>>(
                         logItemsConverter(new SurveyedLocalTieMapper())
                 ) {}
         );

--- a/gws-core/src/main/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/SiteLogMapper.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/SiteLogMapper.java
@@ -26,7 +26,7 @@ import au.gov.ga.geodesy.domain.model.sitelog.SiteLog;
 import au.gov.ga.geodesy.domain.model.sitelog.SurveyedLocalTieLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.TemperatureSensorLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.WaterVaporSensorLogItem;
-import au.gov.ga.geodesy.support.gml.GMLPropertyType;
+import au.gov.ga.geodesy.support.gml.LogItemPropertyType;
 import au.gov.ga.geodesy.support.java.util.Iso;
 import au.gov.xml.icsm.geodesyml.v_0_4.FormInformationType;
 import au.gov.xml.icsm.geodesyml.v_0_4.GnssAntennaPropertyType;
@@ -38,6 +38,7 @@ import au.gov.xml.icsm.geodesyml.v_0_4.SignalObstructionPropertyType;
 import au.gov.xml.icsm.geodesyml.v_0_4.SiteIdentificationType;
 import au.gov.xml.icsm.geodesyml.v_0_4.SiteLocationType;
 import au.gov.xml.icsm.geodesyml.v_0_4.SiteLogType;
+
 import ma.glasnost.orika.MapperFacade;
 import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.MappingContext;
@@ -45,6 +46,7 @@ import ma.glasnost.orika.converter.BidirectionalConverter;
 import ma.glasnost.orika.converter.ConverterFactory;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
 import ma.glasnost.orika.metadata.Type;
+
 import net.opengis.gml.v_3_2_1.AbstractGMLType;
 import net.opengis.iso19139.gmd.v_20070417.CIResponsiblePartyType;
 
@@ -90,43 +92,43 @@ public class SiteLogMapper implements Iso<SiteLogType, SiteLog> {
                 new IsoConverter<SiteLocationType, SiteLocation>(new SiteLocationMapper()) {});
 
         converters.registerConverter("gnssReceivers",
-                new BidirectionalConverterWrapper<List<GMLPropertyType>, Set<GnssReceiverLogItem>>(
+                new BidirectionalConverterWrapper<List<LogItemPropertyType>, Set<GnssReceiverLogItem>>(
                         logItemsConverter(new GnssReceiverMapper())
                 ) {}
         );
 
         converters.registerConverter("frequencyStandards",
-                new BidirectionalConverterWrapper<List<GMLPropertyType>, Set<FrequencyStandardLogItem>>(
+                new BidirectionalConverterWrapper<List<LogItemPropertyType>, Set<FrequencyStandardLogItem>>(
                         logItemsConverter(new FrequencyStandardMapper())
                 ) {}
         );
 
         converters.registerConverter("humiditySensors",
-                new BidirectionalConverterWrapper<List<GMLPropertyType>, Set<HumiditySensorLogItem>>(
+                new BidirectionalConverterWrapper<List<LogItemPropertyType>, Set<HumiditySensorLogItem>>(
                         logItemsConverter(new HumiditySensorMapper())
                 ) {}
         );
 
         converters.registerConverter("pressureSensors",
-                new BidirectionalConverterWrapper<List<GMLPropertyType>, Set<PressureSensorLogItem>>(
+                new BidirectionalConverterWrapper<List<LogItemPropertyType>, Set<PressureSensorLogItem>>(
                         logItemsConverter(new PressureSensorMapper())
                 ) {}
         );
 
         converters.registerConverter("temperatureSensors",
-                new BidirectionalConverterWrapper<List<GMLPropertyType>, Set<TemperatureSensorLogItem>>(
+                new BidirectionalConverterWrapper<List<LogItemPropertyType>, Set<TemperatureSensorLogItem>>(
                         logItemsConverter(new TemperatureSensorMapper())
                 ) {}
         );
 
         converters.registerConverter("waterVaporSensors",
-                new BidirectionalConverterWrapper<List<GMLPropertyType>, Set<WaterVaporSensorLogItem>>(
+                new BidirectionalConverterWrapper<List<LogItemPropertyType>, Set<WaterVaporSensorLogItem>>(
                         logItemsConverter(new WaterVaporSensorMapper())
                 ) {}
         );
 
         converters.registerConverter("otherInstrumentations",
-                new BidirectionalConverterWrapper<List<GMLPropertyType>, Set<OtherInstrumentationLogItem>>(
+                new BidirectionalConverterWrapper<List<LogItemPropertyType>, Set<OtherInstrumentationLogItem>>(
                         logItemsConverter(new OtherInstrumentationMapper())
                 ) {}
         );
@@ -169,13 +171,13 @@ public class SiteLogMapper implements Iso<SiteLogType, SiteLog> {
                 new IsoConverter<FormInformationType, FormInformation>(new FormInformationMapper()) {});
 
         converters.registerConverter("collocationInformations",
-                new BidirectionalConverterWrapper<List<GMLPropertyType>, Set<CollocationInformationLogItem>>(
+                new BidirectionalConverterWrapper<List<LogItemPropertyType>, Set<CollocationInformationLogItem>>(
                         logItemsConverter(new CollocationInformationMapper())
                 ) {}
         );
 
         converters.registerConverter("surveyedLocalTies",
-                new BidirectionalConverterWrapper<List<GMLPropertyType>, Set<SurveyedLocalTieLogItem>>(
+                new BidirectionalConverterWrapper<List<LogItemPropertyType>, Set<SurveyedLocalTieLogItem>>(
                         logItemsConverter(new SurveyedLocalTieMapper())
                 ) {}
         );
@@ -207,16 +209,13 @@ public class SiteLogMapper implements Iso<SiteLogType, SiteLog> {
     }
 
     /**
-     * Given a GMLPropertyType isomorphism (from DTO to domain model), return a
+     * Given a LogItemPropertyType isomorphism (from DTO to domain model), return a
      * bidirectional converter from a list of GML property types to a
      * set of domain model log items.
      */
-    private <P extends GMLPropertyType, T extends AbstractGMLType, L extends LogItem>
+    private <P extends LogItemPropertyType, T extends AbstractGMLType, L extends LogItem>
     BidirectionalConverter<List<P>, Set<L>> logItemsConverter(Iso<T, L> logItemsIso) {
-
-        Iso<P, T> propertyIso = new GMLPropertyTypeMapper<>();
-        Iso<P, L> elementIso = propertyIso.compose(logItemsIso);
-        return new IsoConverter<>(new ListToSet<>(elementIso));
+        return new IsoConverter<>(new ListToSet<>(new LogItemPropertyTypeMapper<>(logItemsIso)));
     }
 
     /**

--- a/gws-core/src/main/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/SiteLogMapper.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/SiteLogMapper.java
@@ -220,18 +220,6 @@ public class SiteLogMapper implements Iso<SiteLogType, SiteLog> {
     }
 
     /**
-     * Given an equipment isomorphism (from DTO to domain model), return a
-     * bidirectional converter from a list of GML equipment property types to a
-     * set of domain model collocation information.
-     */
-    private <P extends GMLPropertyType, T extends AbstractGMLType, L extends Object>
-    BidirectionalConverter<List<P>, Set<L>> infoCollectionConverter(Iso<T, L> infoIso) {
-        Iso<P, T> propertyIso = new GMLPropertyTypeMapper<>();
-        Iso<P, L> elementIso = propertyIso.compose(infoIso);
-        return new IsoConverter<>(new ListToSet<>(elementIso));
-    }
-
-    /**
      * Given an isomorphism from A to B, return an isomorphism from a set of A
      * to a set B.
      */

--- a/gws-core/src/main/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/SiteLogMapper.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/SiteLogMapper.java
@@ -176,7 +176,7 @@ public class SiteLogMapper implements Iso<SiteLogType, SiteLog> {
 
         converters.registerConverter("surveyedLocalTies",
                 new BidirectionalConverterWrapper<List<GMLPropertyType>, Set<SurveyedLocalTie>>(
-                        infoCollectionConverter(new SurveyedLocalTieMapper())
+                        logItemsConverter(new SurveyedLocalTieMapper())
                 ) {}
         );
 

--- a/gws-core/src/main/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/SiteLogMapper.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/SiteLogMapper.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 
 import org.opengis.metadata.citation.ResponsibleParty;
 
-import au.gov.ga.geodesy.domain.model.sitelog.CollocationInformation;
+import au.gov.ga.geodesy.domain.model.sitelog.CollocationInformationLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.FormInformation;
 import au.gov.ga.geodesy.domain.model.sitelog.FrequencyStandardLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.GnssAntennaLogItem;
@@ -169,7 +169,7 @@ public class SiteLogMapper implements Iso<SiteLogType, SiteLog> {
                 new IsoConverter<FormInformationType, FormInformation>(new FormInformationMapper()) {});
 
         converters.registerConverter("collocationInformations",
-                new BidirectionalConverterWrapper<List<GMLPropertyType>, Set<CollocationInformation>>(
+                new BidirectionalConverterWrapper<List<GMLPropertyType>, Set<CollocationInformationLogItem>>(
                         logItemsConverter(new CollocationInformationMapper())
                 ) {}
         );

--- a/gws-core/src/main/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/SiteLogMapper.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/SiteLogMapper.java
@@ -170,7 +170,7 @@ public class SiteLogMapper implements Iso<SiteLogType, SiteLog> {
 
         converters.registerConverter("collocationInformations",
                 new BidirectionalConverterWrapper<List<GMLPropertyType>, Set<CollocationInformation>>(
-                        infoCollectionConverter(new CollocationInformationMapper())
+                        logItemsConverter(new CollocationInformationMapper())
                 ) {}
         );
 

--- a/gws-core/src/main/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/SurveyedLocalTieMapper.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/SurveyedLocalTieMapper.java
@@ -1,7 +1,7 @@
 package au.gov.ga.geodesy.support.mapper.orika.geodesyml;
 
 import au.gov.ga.geodesy.domain.model.sitelog.DifferentialFromMarker;
-import au.gov.ga.geodesy.domain.model.sitelog.SurveyedLocalTie;
+import au.gov.ga.geodesy.domain.model.sitelog.SurveyedLocalTieLogItem;
 import au.gov.ga.geodesy.support.java.util.Iso;
 import au.gov.xml.icsm.geodesyml.v_0_4.SurveyedLocalTieType;
 import ma.glasnost.orika.MapperFacade;
@@ -13,13 +13,13 @@ import ma.glasnost.orika.impl.DefaultMapperFactory;
  * Reversible mapping between GeodesyML SurveyedLocalTiesType DTO and
  * SurveyedLocalTie site log entity.
  */
-public class SurveyedLocalTieMapper implements Iso<SurveyedLocalTieType, SurveyedLocalTie> {
+public class SurveyedLocalTieMapper implements Iso<SurveyedLocalTieType, SurveyedLocalTieLogItem> {
 
     private MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
     private MapperFacade mapper;
 
     public SurveyedLocalTieMapper() {
-        mapperFactory.classMap(SurveyedLocalTieType.class, SurveyedLocalTie.class)
+        mapperFactory.classMap(SurveyedLocalTieType.class, SurveyedLocalTieLogItem.class)
                 .field("tiedMarkerCDPNumber", "tiedMarkerCdpNumber")
                 .field("tiedMarkerDOMESNumber", "tiedMarkerDomesNumber")
                 .field("differentialComponentsGNSSMarkerToTiedMonumentITRS", "differentialFromMarker")
@@ -43,14 +43,14 @@ public class SurveyedLocalTieMapper implements Iso<SurveyedLocalTieType, Surveye
     /**
      * {@inheritDoc}
      */
-    public SurveyedLocalTie to(SurveyedLocalTieType SurveyedLocalTieType) {
-        return mapper.map(SurveyedLocalTieType, SurveyedLocalTie.class);
+    public SurveyedLocalTieLogItem to(SurveyedLocalTieType SurveyedLocalTieType) {
+        return mapper.map(SurveyedLocalTieType, SurveyedLocalTieLogItem.class);
     }
 
     /**
      * {@inheritDoc}
      */
-    public SurveyedLocalTieType from(SurveyedLocalTie SurveyedLocalTie) {
+    public SurveyedLocalTieType from(SurveyedLocalTieLogItem SurveyedLocalTie) {
         return mapper.map(SurveyedLocalTie, SurveyedLocalTieType.class);
     }
 }

--- a/gws-core/src/main/resources/db/add-date-inserted-change-tracking-columns.xml
+++ b/gws-core/src/main/resources/db/add-date-inserted-change-tracking-columns.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="lbodor" id="1498218194-1">
+        <addColumn
+            tableName="sitelog_mutlipathsource">
+            <column
+                name="date_inserted"
+                remarks="datetime the record was inserted into the log"
+                type="timestamp"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498218194-2">
+        <addColumn
+            tableName="sitelog_signalobstraction">
+            <column
+                name="date_inserted"
+                remarks="datetime the record was inserted into the log"
+                type="timestamp"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498218194-3">
+        <addColumn
+            tableName="sitelog_radiointerference">
+            <column name="date_inserted"
+                remarks="datetime the record was inserted into the log"
+                type="timestamp"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498218194-4">
+        <addColumn
+            tableName="sitelog_localepisodiceffect">
+            <column name="date_inserted"
+                remarks="datetime the record was inserted into the log"
+                type="timestamp"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498218194-5">
+        <addColumn
+            tableName="sitelog_otherinstrumentation">
+            <column name="date_inserted"
+                remarks="datetime the record was inserted into the log"
+                type="timestamp"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498218194-6">
+        <addColumn
+            tableName="sitelog_collocationinformation">
+            <column name="date_inserted"
+                remarks="datetime the record was inserted into the log"
+                type="timestamp"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498218194-7">
+        <addColumn
+            tableName="sitelog_frequencystandard">
+            <column name="date_inserted"
+                remarks="datetime the record was inserted into the log"
+                type="timestamp"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498218194-8">
+        <addColumn
+            tableName="sitelog_gnssreceiver">
+            <column name="date_inserted"
+                remarks="datetime the record was inserted into the log"
+                type="timestamp"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498218194-9">
+        <addColumn
+            tableName="sitelog_watervaporsensor">
+            <column name="date_inserted"
+                remarks="datetime the record was inserted into the log"
+                type="timestamp"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498218194-10">
+        <addColumn
+            tableName="sitelog_pressuresensor">
+            <column name="date_inserted"
+                remarks="datetime the record was inserted into the log"
+                type="timestamp"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498218194-11">
+        <addColumn
+            tableName="sitelog_humiditysensor">
+            <column name="date_inserted"
+                remarks="datetime the record was inserted into the log"
+                type="timestamp"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498218194-12">
+        <addColumn
+            tableName="sitelog_surveyedlocaltie">
+            <column name="date_inserted"
+                remarks="datetime the record was inserted into the log"
+                type="timestamp"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498218194-13">
+        <addColumn
+            tableName="sitelog_temperaturesensor">
+            <column name="date_inserted"
+                remarks="datetime the record was inserted into the log"
+                type="timestamp"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498218194-14">
+        <addColumn
+            tableName="sitelog_gnssantenna">
+            <column name="date_inserted"
+                remarks="datetime the record was inserted into the log"
+                type="timestamp"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/gws-core/src/main/resources/db/geodesy-database-changelog.xml
+++ b/gws-core/src/main/resources/db/geodesy-database-changelog.xml
@@ -53,4 +53,5 @@
     <include file="db/add-cors-network-name-constraints.xml"/>
     <include file="db/add-index-column-to-responsible-parties.xml"/>
     <include file="db/add-new-cors-site-request.xml"/>
+    <include file="db/rename-change-tracking-columns.xml"/>
 </databaseChangeLog>

--- a/gws-core/src/main/resources/db/geodesy-database-changelog.xml
+++ b/gws-core/src/main/resources/db/geodesy-database-changelog.xml
@@ -54,4 +54,5 @@
     <include file="db/add-index-column-to-responsible-parties.xml"/>
     <include file="db/add-new-cors-site-request.xml"/>
     <include file="db/rename-change-tracking-columns.xml"/>
+    <include file="db/add-date-inserted-change-tracking-columns.xml"/>
 </databaseChangeLog>

--- a/gws-core/src/main/resources/db/rename-change-tracking-columns.xml
+++ b/gws-core/src/main/resources/db/rename-change-tracking-columns.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="lbodor" id="1498217709-1">
+        <renameColumn
+            tableName="sitelog_mutlipathsource"
+            oldColumnName="delete_reason"
+            newColumnName="deleted_reason"/>
+    </changeSet>
+    <changeSet author="lbodor" id="1498217709-2">
+        <renameColumn
+            tableName="sitelog_mutlipathsource"
+            oldColumnName="delete_time"
+            newColumnName="date_deleted"/>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498217709-3">
+        <renameColumn
+            tableName="sitelog_signalobstraction"
+            oldColumnName="delete_reason"
+            newColumnName="deleted_reason"/>
+    </changeSet>
+    <changeSet author="lbodor" id="1498217709-4">
+        <renameColumn
+            tableName="sitelog_signalobstraction"
+            oldColumnName="delete_time"
+            newColumnName="date_deleted"/>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498217709-5">
+        <renameColumn
+            tableName="sitelog_radiointerference"
+            oldColumnName="delete_reason"
+            newColumnName="deleted_reason"/>
+    </changeSet>
+    <changeSet author="lbodor" id="1498217709-6">
+        <renameColumn
+            tableName="sitelog_radiointerference"
+            oldColumnName="delete_time"
+            newColumnName="date_deleted"/>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498217709-7">
+        <renameColumn
+            tableName="sitelog_localepisodiceffect"
+            oldColumnName="delete_reason"
+            newColumnName="deleted_reason"/>
+    </changeSet>
+    <changeSet author="lbodor" id="1498217709-8">
+        <renameColumn
+            tableName="sitelog_localepisodiceffect"
+            oldColumnName="delete_time"
+            newColumnName="date_deleted"/>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498217709-9">
+        <renameColumn
+            tableName="sitelog_otherinstrumentation"
+            oldColumnName="delete_reason"
+            newColumnName="deleted_reason"/>
+    </changeSet>
+    <changeSet author="lbodor" id="1498217709-10">
+        <renameColumn
+            tableName="sitelog_otherinstrumentation"
+            oldColumnName="delete_time"
+            newColumnName="date_deleted"/>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498217709-11">
+        <renameColumn
+            tableName="sitelog_collocationinformation"
+            oldColumnName="delete_reason"
+            newColumnName="deleted_reason"/>
+    </changeSet>
+    <changeSet author="lbodor" id="1498217709-12">
+        <renameColumn
+            tableName="sitelog_collocationinformation"
+            oldColumnName="delete_time"
+            newColumnName="date_deleted"/>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498217709-13">
+        <renameColumn
+            tableName="sitelog_frequencystandard"
+            oldColumnName="delete_reason"
+            newColumnName="deleted_reason"/>
+    </changeSet>
+    <changeSet author="lbodor" id="1498217709-14">
+        <renameColumn
+            tableName="sitelog_frequencystandard"
+            oldColumnName="delete_time"
+            newColumnName="date_deleted"/>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498217709-15">
+        <renameColumn
+            tableName="sitelog_gnssreceiver"
+            oldColumnName="delete_reason"
+            newColumnName="deleted_reason"/>
+    </changeSet>
+    <changeSet author="lbodor" id="1498217709-16">
+        <renameColumn tableName="sitelog_gnssreceiver"
+            oldColumnName="delete_time"
+            newColumnName="date_deleted"/>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498217709-17">
+        <renameColumn
+            tableName="sitelog_watervaporsensor"
+            oldColumnName="delete_reason"
+            newColumnName="deleted_reason"/>
+    </changeSet>
+    <changeSet author="lbodor" id="1498217709-18">
+        <renameColumn
+            tableName="sitelog_watervaporsensor"
+            oldColumnName="delete_time"
+            newColumnName="date_deleted"/>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498217709-19">
+        <renameColumn
+            tableName="sitelog_pressuresensor"
+            oldColumnName="delete_reason"
+            newColumnName="deleted_reason"/>
+    </changeSet>
+    <changeSet author="lbodor" id="1498217709-20">
+        <renameColumn
+            tableName="sitelog_pressuresensor"
+            oldColumnName="delete_time"
+            newColumnName="date_deleted"/>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498217709-21">
+        <renameColumn
+            tableName="sitelog_humiditysensor"
+            oldColumnName="delete_reason"
+            newColumnName="deleted_reason"/>
+    </changeSet>
+    <changeSet author="lbodor" id="1498217709-22">
+        <renameColumn
+            tableName="sitelog_humiditysensor"
+            oldColumnName="delete_time"
+            newColumnName="date_deleted"/>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498217709-23">
+        <renameColumn
+            tableName="sitelog_surveyedlocaltie"
+            oldColumnName="delete_reason"
+            newColumnName="deleted_reason"/>
+    </changeSet>
+    <changeSet author="lbodor" id="1498217709-24">
+        <renameColumn
+            tableName="sitelog_surveyedlocaltie"
+            oldColumnName="delete_time"
+            newColumnName="date_deleted"/>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498217709-25">
+        <renameColumn
+            tableName="sitelog_temperaturesensor"
+            oldColumnName="delete_reason"
+            newColumnName="deleted_reason"/>
+    </changeSet>
+    <changeSet author="lbodor" id="1498217709-26">
+        <renameColumn
+            tableName="sitelog_temperaturesensor"
+            oldColumnName="delete_time"
+            newColumnName="date_deleted"/>
+    </changeSet>
+
+    <changeSet author="lbodor" id="1498217709-27">
+        <renameColumn
+            tableName="sitelog_gnssantenna"
+            oldColumnName="delete_reason"
+            newColumnName="deleted_reason"/>
+    </changeSet>
+    <changeSet author="lbodor" id="1498217709-28">
+        <renameColumn
+            tableName="sitelog_gnssantenna"
+            oldColumnName="delete_time"
+            newColumnName="date_deleted"/>
+    </changeSet>
+</databaseChangeLog>

--- a/gws-core/src/test/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/CollocationInformationMapperTest.java
+++ b/gws-core/src/test/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/CollocationInformationMapperTest.java
@@ -6,7 +6,7 @@ import static org.hamcrest.core.Is.is;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
-import au.gov.ga.geodesy.domain.model.sitelog.CollocationInformation;
+import au.gov.ga.geodesy.domain.model.sitelog.CollocationInformationLogItem;
 import au.gov.ga.geodesy.port.adapter.geodesyml.GeodesyMLMarshaller;
 import au.gov.ga.geodesy.port.adapter.geodesyml.GeodesyMLUtils;
 import au.gov.ga.geodesy.support.TestResources;
@@ -41,7 +41,7 @@ public class CollocationInformationMapperTest {
             .findFirst().get();
 
         CollocationInformationType collocationInfoTypeA = siteLog.getCollocationInformations().get(0).getCollocationInformation();
-        CollocationInformation collocationInfo = mapper.to(collocationInfoTypeA);
+        CollocationInformationLogItem collocationInfo = mapper.to(collocationInfoTypeA);
 
         assertThat(collocationInfo.getInstrumentType(), is(collocationInfoTypeA.getInstrumentationType().getValue()));
         assertThat(collocationInfo.getStatus(), is(String.valueOf(collocationInfoTypeA.getStatus().getValue())));

--- a/gws-core/src/test/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/LogItemPropertyTypeMapperTest.java
+++ b/gws-core/src/test/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/LogItemPropertyTypeMapperTest.java
@@ -1,0 +1,63 @@
+package au.gov.ga.geodesy.support.mapper.orika.geodesyml;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import java.time.Instant;
+
+import org.junit.Test;
+
+import au.gov.ga.geodesy.domain.model.sitelog.GnssReceiverLogItem;
+import au.gov.ga.geodesy.support.utils.DateTimeFormatDecorator;
+import au.gov.ga.geodesy.support.utils.GMLDateUtils;
+import au.gov.xml.icsm.geodesyml.v_0_4.GnssReceiverPropertyType;
+import au.gov.xml.icsm.geodesyml.v_0_4.GnssReceiverType;
+
+import net.opengis.gml.v_3_2_1.TimePositionType;
+
+public class LogItemPropertyTypeMapperTest {
+
+    private LogItemPropertyTypeMapper<GnssReceiverPropertyType, GnssReceiverType, GnssReceiverLogItem> mapper
+        = new LogItemPropertyTypeMapper<>(new GnssReceiverMapper());
+
+    @Test
+    public void mapFromDto() {
+        Instant dateInserted = Instant.now().minusMillis(2000);
+        Instant dateDeleted = Instant.now().minusMillis(1000);
+        String deletedReason = "deleted reason";
+        String serialNumber = "1";
+
+        // DTO to domain
+        GnssReceiverPropertyType receiverProperty = new GnssReceiverPropertyType()
+            .withGnssReceiver(
+                new GnssReceiverType()
+                    .withManufacturerSerialNumber(serialNumber)
+            )
+            .withDateInserted(timePosition(dateInserted))
+            .withDateDeleted(timePosition(dateDeleted))
+            .withDeletedReason(deletedReason)
+        ;
+
+        GnssReceiverLogItem receiver = mapper.to(receiverProperty);
+        assertThat(receiver.getSerialNumber(), is(equalTo(serialNumber)));
+
+        assertThat(receiver.getDateInserted(), is(equalTo(dateInserted)));
+        assertThat(receiver.getDateDeleted(), is(equalTo(dateDeleted)));
+        assertThat(receiver.getDeletedReason(), is(equalTo(deletedReason)));
+
+        // domain to DTO
+        GnssReceiverPropertyType receiverPropertyB = mapper.from(receiver);
+        assertThat(receiverPropertyB.getGnssReceiver().getManufacturerSerialNumber(), is(equalTo(serialNumber)));
+
+        assertThat(receiverPropertyB.getDateInserted(), is(equalTo(timePosition(dateInserted))));
+        assertThat(receiverPropertyB.getDateDeleted(), is(equalTo(timePosition(dateDeleted))));
+        assertThat(receiverPropertyB.getDeletedReason(), is(equalTo(deletedReason)));
+    }
+
+    private TimePositionType timePosition(Instant date) {
+        TimePositionType timePosition = new TimePositionType();
+        timePosition.getValue().add(GMLDateUtils.dateToString(date, DateTimeFormatDecorator.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSX")));
+        return timePosition;
+    }
+}

--- a/gws-core/src/test/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/SiteLogMapperITest.java
+++ b/gws-core/src/test/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/SiteLogMapperITest.java
@@ -37,7 +37,7 @@ import au.gov.ga.geodesy.domain.model.sitelog.PressureSensorLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.RadioInterference;
 import au.gov.ga.geodesy.domain.model.sitelog.SignalObstructionLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.SiteLog;
-import au.gov.ga.geodesy.domain.model.sitelog.SurveyedLocalTie;
+import au.gov.ga.geodesy.domain.model.sitelog.SurveyedLocalTieLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.TemperatureSensorLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.WaterVaporSensorLogItem;
 import au.gov.ga.geodesy.port.adapter.geodesyml.GeodesyMLMarshaller;
@@ -472,7 +472,7 @@ public class SiteLogMapperITest extends IntegrationTest {
 
         {
             int i = 0;
-            for (SurveyedLocalTie surveyedLocalTie : sortSurveyedLocalTies(siteLog.getSurveyedLocalTies())) {
+            for (SurveyedLocalTieLogItem surveyedLocalTie : sortSurveyedLocalTies(siteLog.getSurveyedLocalTies())) {
                 SurveyedLocalTieType surveyedLocalTiesType = surveyedLocalTies.get(i++).getSurveyedLocalTie();
                 assertThat(surveyedLocalTie.getTiedMarkerName(), is(surveyedLocalTiesType.getTiedMarkerName()));
                 assertThat(surveyedLocalTie.getTiedMarkerUsage(), is(surveyedLocalTiesType.getTiedMarkerUsage()));
@@ -663,7 +663,7 @@ public class SiteLogMapperITest extends IntegrationTest {
     /**
      * Sort a set of SurveyedLocalTies by tied marker names.
      */
-    private <T extends SurveyedLocalTie> SortedSet<T> sortSurveyedLocalTies(Set<T> info) {
+    private <T extends SurveyedLocalTieLogItem> SortedSet<T> sortSurveyedLocalTies(Set<T> info) {
         SortedSet<T> sorted = new TreeSet<>(new Comparator<T>() {
             public int compare(T e, T f) {
                 int c = e.getTiedMarkerName().compareTo(f.getTiedMarkerName());

--- a/gws-core/src/test/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/SiteLogMapperITest.java
+++ b/gws-core/src/test/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/SiteLogMapperITest.java
@@ -24,7 +24,7 @@ import org.testng.annotations.Test;
 
 import com.vividsolutions.jts.geom.Point;
 
-import au.gov.ga.geodesy.domain.model.sitelog.CollocationInformation;
+import au.gov.ga.geodesy.domain.model.sitelog.CollocationInformationLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.FrequencyStandardLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.GnssAntennaLogItem;
 import au.gov.ga.geodesy.domain.model.sitelog.GnssReceiverLogItem;
@@ -436,7 +436,7 @@ public class SiteLogMapperITest extends IntegrationTest {
 
         {
             int i = 0;
-            for (CollocationInformation collocationInfo : sortCollocationInformations(siteLog.getCollocationInformation())) {
+            for (CollocationInformationLogItem collocationInfo : sortCollocationInformations(siteLog.getCollocationInformation())) {
                 CollocationInformationType collocationInfoType = collocationInfoProperties.get(i++).getCollocationInformation();
                 assertThat(collocationInfo.getInstrumentType(), is(collocationInfoType.getInstrumentationType().getValue()));
 
@@ -627,7 +627,7 @@ public class SiteLogMapperITest extends IntegrationTest {
     /**
      * Sort a set of CollocationInformations by effective dates.
      */
-    private <T extends CollocationInformation> SortedSet<T> sortCollocationInformations(Set<T> info) {
+    private <T extends CollocationInformationLogItem> SortedSet<T> sortCollocationInformations(Set<T> info) {
         SortedSet<T> sorted = new TreeSet<>(new Comparator<T>() {
             public int compare(T e, T f) {
                 int c = e.getEffectiveDates().compareTo(f.getEffectiveDates());

--- a/gws-core/src/test/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/SurveyedLocalTieMapperTest.java
+++ b/gws-core/src/test/java/au/gov/ga/geodesy/support/mapper/orika/geodesyml/SurveyedLocalTieMapperTest.java
@@ -1,6 +1,6 @@
 package au.gov.ga.geodesy.support.mapper.orika.geodesyml;
 
-import au.gov.ga.geodesy.domain.model.sitelog.SurveyedLocalTie;
+import au.gov.ga.geodesy.domain.model.sitelog.SurveyedLocalTieLogItem;
 import au.gov.ga.geodesy.port.adapter.geodesyml.GeodesyMLMarshaller;
 import au.gov.ga.geodesy.port.adapter.geodesyml.GeodesyMLUtils;
 import au.gov.ga.geodesy.support.TestResources;
@@ -34,7 +34,7 @@ public class SurveyedLocalTieMapperTest {
                 .findFirst().get();
 
         SurveyedLocalTieType surveyedLocalTiesA = siteLogType.getSurveyedLocalTies().get(0).getSurveyedLocalTie();
-        SurveyedLocalTie surveyedLocalTie = mapper.to(surveyedLocalTiesA);
+        SurveyedLocalTieLogItem surveyedLocalTie = mapper.to(surveyedLocalTiesA);
         assertThat(surveyedLocalTie.getTiedMarkerName(), is(surveyedLocalTiesA.getTiedMarkerName()));
         assertThat(surveyedLocalTie.getTiedMarkerUsage(), is(surveyedLocalTiesA.getTiedMarkerUsage()));
         assertThat(surveyedLocalTie.getTiedMarkerCdpNumber(), is(surveyedLocalTiesA.getTiedMarkerCDPNumber()));


### PR DESCRIPTION
Persist site log items along with their change tracking attributes, but disregard deleted log items when computing setups.

Note that this pull request is stacked on top of #505.