### PR TITLE
Reduce CI log output

### DIFF
--- a/travis/build.sh
+++ b/travis/build.sh
@@ -8,7 +8,7 @@ sudo rm -f /etc/mavenrc
 
 # We redirect maven test output to file, because Travis CI limits stdout log size to 4MB.
 
-mvn --settings ./travis/maven-settings.xml -U install -DskipTests
+mvn --settings ./travis/maven-settings.xml -U install -DskipTests > /dev/null
 
 if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
     mvn --settings ./travis/maven-settings.xml deploy -pl '!gws-system-test' -DredirectTestOutputToFile


### PR DESCRIPTION
Travis allows logs up to 4MB.