### PR TITLE
Don't exit on error from docker containers

### DIFF
--- a/gws-tomcat/entrypoint.sh
+++ b/gws-tomcat/entrypoint.sh
@@ -9,4 +9,6 @@ if [ -d /webapps ]; then
     rsync --ignore-missing-args -ur /webapps/ "${TOMCAT_HOME}"/webapps/
 fi
 
+set +e
+
 exec "$@"

--- a/gws-tomcat/env.sh
+++ b/gws-tomcat/env.sh
@@ -21,3 +21,5 @@ function wait_for_tomcat {
         sleep 10
     done
 }
+
+set +e


### PR DESCRIPTION
This is a problem when running bash in docker, where any error at the
promp terminates the container.