### PR TITLE
Delete humidity sensors when deleting equipment

### DIFF
--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/equipment/HumiditySensorRepository.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/model/equipment/HumiditySensorRepository.java
@@ -1,0 +1,6 @@
+package au.gov.ga.geodesy.domain.model.equipment;
+
+import au.gov.ga.geodesy.support.spring.AggregateRepository;
+
+public interface HumiditySensorRepository extends AggregateRepository<HumiditySensor> {
+}

--- a/gws-core/src/main/java/au/gov/ga/geodesy/domain/service/SetupService.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/domain/service/SetupService.java
@@ -23,6 +23,7 @@ import au.gov.ga.geodesy.domain.model.SetupRepository;
 import au.gov.ga.geodesy.domain.model.SetupType;
 import au.gov.ga.geodesy.domain.model.equipment.EquipmentConfigurationRepository;
 import au.gov.ga.geodesy.domain.model.equipment.EquipmentRepository;
+import au.gov.ga.geodesy.domain.model.equipment.HumiditySensorRepository;
 import au.gov.ga.geodesy.domain.model.sitelog.SiteLog;
 import au.gov.ga.geodesy.domain.model.sitelog.SiteLogRepository;
 
@@ -53,6 +54,9 @@ public class SetupService {
     @Autowired
     private EquipmentRepository equipment;
 
+    @Autowired
+    private HumiditySensorRepository humiditySensors;
+
     @PersistenceContext
     private EntityManager entityManager;
 
@@ -75,6 +79,11 @@ public class SetupService {
     public void deleteSetups() {
         setups.deleteAllInBatch();
         equipmentConfigurations.deleteAllInBatch();
+
+        // TODO: Remove in the next release to production, because humidity sensors are
+        // no longer created as part of CorsSetups.
+        humiditySensors.deleteAllInBatch();
+
         equipment.deleteAllInBatch();
     }
 


### PR DESCRIPTION
This change could optionally be rolled back for the next release to production,
because humidity sensors are no longer created for CorsSetups.