### PR TITLE
Change to return document url embedded in response body

### DIFF
--- a/gws-core/src/test/java/au/gov/ga/geodesy/port/adapter/rest/AssociatedDocumentEndpointITest.java
+++ b/gws-core/src/test/java/au/gov/ga/geodesy/port/adapter/rest/AssociatedDocumentEndpointITest.java
@@ -3,7 +3,7 @@ package au.gov.ga.geodesy.port.adapter.rest;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.fileUpload;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import static au.gov.ga.geodesy.port.adapter.rest.ResultHandlers.print;
@@ -32,7 +32,7 @@ public class AssociatedDocumentEndpointITest extends IntegrationTest {
             .with(super.superuserToken()))
             .andDo(print)
             .andExpect(status().isCreated())
-            .andExpect(header().string("location", this.fileReference));
+            .andExpect(content().string(containsString(this.fileReference)));
     }
 
     @Test(dependsOnMethods = {"uploadDocument"})


### PR DESCRIPTION
Have to roll back part of the changes made in previous PR because that we could not retrieve the url of uploaded documents from response header location in GNSS-SITE-MANAGER. I'll attach snapshots showing the difference in Slack for reference.