### PR TITLE
Fix unset variables error in aws/deploy.sh

### DIFF
--- a/aws/deploy.sh
+++ b/aws/deploy.sh
@@ -14,6 +14,7 @@ function usage {
     exit 1
 }
 
+dryRun=""
 while [[ $# -gt 0 ]]; do
     case $1 in
         -d|--dry-run )


### PR DESCRIPTION
Alternative solution is to remove "-u" from "set -eEuo pipefail". However, unset variables are a common cause of bugs in shell scripts, so having unset variables cause an immediate exit is often highly desirable behavior.