### PR TITLE
Release 0.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ services:
 - docker
 branches:
   only:
-  - master
-  - next
-  - release-0.2.0
   - geodesyml-0.4
 cache:
   timeout: 86400

--- a/gws-core/pom.xml
+++ b/gws-core/pom.xml
@@ -5,7 +5,7 @@
     <name>Geodesy Web Services Core</name>
     <groupId>au.gov.ga.geodesy.gws</groupId>
     <artifactId>gws-core</artifactId>
-    <version>0.2.1</version>
+    <version>0.2.2</version>
     <packaging>jar</packaging>
 
     <scm>
@@ -16,7 +16,7 @@
     <parent>
         <groupId>au.gov.ga.geodesy.gws</groupId>
         <artifactId>gws-parent</artifactId>
-        <version>0.2.1</version>
+        <version>0.2.2</version>
         <relativePath>../gws-parent</relativePath>
     </parent>
     <properties>
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>au.gov.ga.geodesy</groupId>
             <artifactId>igssitelog-bindings</artifactId>
-            <version>0.1.0</version>
+            <version>0.3.0</version>
         </dependency>
         <dependency>
             <groupId>au.gov.ga</groupId>
@@ -139,7 +139,7 @@
         <dependency>
             <groupId>au.gov.ga.geodesy</groupId>
             <artifactId>geodesyml</artifactId>
-            <version>0.2.0-SNAPSHOT</version>
+            <version>0.2.0</version>
             <classifier>xsd</classifier>
             <type>zip</type>
         </dependency>
@@ -427,7 +427,7 @@
                                 <artifactItem>
                                     <groupId>au.gov.ga.geodesy</groupId>
                                     <artifactId>geodesyml</artifactId>
-                                    <version>0.2.0-SNAPSHOT</version>
+                                    <version>0.2.0</version>
                                     <classifier>xsd</classifier>
                                     <type>zip</type>
                                 </artifactItem>

--- a/gws-core/src/main/java/au/gov/ga/geodesy/port/adapter/geodesyml/GeodesyMLValidator.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/port/adapter/geodesyml/GeodesyMLValidator.java
@@ -28,7 +28,7 @@ public class GeodesyMLValidator {
     public GeodesyMLValidator(String catalogPath) {
 
         try {
-            URL schemaUrl = ResourceUtils.getURL("classpath:xsd/geodesyml-0.2.0-SNAPSHOT/geodesyml/0.4/geodesyML.xsd");
+            URL schemaUrl = ResourceUtils.getURL("classpath:xsd/geodesyml-0.2.0/geodesyml/0.4/geodesyML.xsd");
             Source xsdSource = new StreamSource(schemaUrl.openStream());
             schemaValidator = new SchemaValidator(xsdSource, catalogPath);
         }

--- a/gws-core/src/test/java/au/gov/ga/geodesy/port/adapter/geodesyml/GeodesyMLValidatorTest.java
+++ b/gws-core/src/test/java/au/gov/ga/geodesy/port/adapter/geodesyml/GeodesyMLValidatorTest.java
@@ -24,7 +24,7 @@ public class GeodesyMLValidatorTest  {
     public void setup() {
 
         try (ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext()) {
-            Resource catalogResource = context.getResource("classpath:xsd/geodesyml-0.2.0-SNAPSHOT/catalog.xml");
+            Resource catalogResource = context.getResource("classpath:xsd/geodesyml-0.2.0/catalog.xml");
             String catalogPath = catalogResource.getFile().getAbsolutePath();
             geodesyMLValidator = new GeodesyMLValidator(catalogPath);
         } catch (IOException e) {

--- a/gws-core/src/test/java/au/gov/ga/geodesy/support/spring/GeodesyServiceTestConfig.java
+++ b/gws-core/src/test/java/au/gov/ga/geodesy/support/spring/GeodesyServiceTestConfig.java
@@ -23,7 +23,7 @@ public class GeodesyServiceTestConfig extends GeodesyServiceConfig {
 
     @Bean
     public GeodesyMLValidator getGeodesyMLValidator() throws FileNotFoundException {
-        String catalog = ResourceUtils.getFile("file:target/generated-resources/xsd/geodesyml-0.2.0-SNAPSHOT/catalog.xml").getAbsolutePath();
+        String catalog = ResourceUtils.getFile("file:target/generated-resources/xsd/geodesyml-0.2.0/catalog.xml").getAbsolutePath();
         return new GeodesyMLValidator(catalog);
     }
 

--- a/gws-parent/pom.xml
+++ b/gws-parent/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>au.gov.ga.geodesy.gws</groupId>
     <artifactId>gws-parent</artifactId>
-    <version>0.2.1</version>
+    <version>0.2.2</version>
     <packaging>pom</packaging>
     <name>Geodesy Web Services Parent</name>
     <issueManagement>

--- a/gws-system-test/pom.xml
+++ b/gws-system-test/pom.xml
@@ -5,7 +5,7 @@
     <name>Geodesy Web Services System Tests</name>
     <groupId>au.gov.ga.geodesy.gws</groupId>
     <artifactId>gws-system-test</artifactId>
-    <version>0.2.1</version>
+    <version>0.2.2</version>
     <packaging>jar</packaging>
     <scm>
         <connection>scm:git:git@github.com:GeoscienceAustralia/geodesy-web-services.git</connection>
@@ -15,7 +15,7 @@
     <parent>
         <groupId>au.gov.ga.geodesy.gws</groupId>
         <artifactId>gws-parent</artifactId>
-        <version>0.2.1</version>
+        <version>0.2.2</version>
         <relativePath>../gws-parent</relativePath>
     </parent>
     <properties>

--- a/gws-webapp/pom.xml
+++ b/gws-webapp/pom.xml
@@ -5,7 +5,7 @@
     <name>Geodesy Web Services Web Application</name>
     <groupId>au.gov.ga.geodesy.gws</groupId>
     <artifactId>gws-webapp</artifactId>
-    <version>0.2.1</version>
+    <version>0.2.2</version>
     <packaging>war</packaging>
     <scm>
         <connection>scm:git:git@github.com:GeoscienceAustralia/geodesy-web-services.git</connection>
@@ -15,7 +15,7 @@
     <parent>
         <groupId>au.gov.ga.geodesy.gws</groupId>
         <artifactId>gws-parent</artifactId>
-        <version>0.2.1</version>
+        <version>0.2.2</version>
         <relativePath>../gws-parent</relativePath>
     </parent>
     <properties>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>gws-core</artifactId>
-            <version>0.2.1</version>
+            <version>0.2.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework</groupId>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>au.gov.ga.geodesy</groupId>
             <artifactId>geodesyml</artifactId>
-            <version>0.2.0-SNAPSHOT</version>
+            <version>0.2.0</version>
             <classifier>xsd</classifier>
             <type>zip</type>
         </dependency>
@@ -107,7 +107,7 @@
                                 <artifactItem>
                                     <groupId>au.gov.ga.geodesy</groupId>
                                     <artifactId>geodesyml</artifactId>
-                                    <version>0.2.0-SNAPSHOT</version>
+                                    <version>0.2.0</version>
                                     <classifier>xsd</classifier>
                                     <type>zip</type>
                                 </artifactItem>

--- a/gws-webapp/src/main/java/au/gov/ga/geodesy/support/spring/WebAppConfig.java
+++ b/gws-webapp/src/main/java/au/gov/ga/geodesy/support/spring/WebAppConfig.java
@@ -50,7 +50,7 @@ public class WebAppConfig {
         try {
             // TODO: find the best way to load resources, javadoc says that ResourceUtils is
             // mosty a spring-internal utility class.
-            URL catalogURL = ResourceUtils.getURL("classpath:xsd/geodesyml-0.2.0-SNAPSHOT/catalog.xml");
+            URL catalogURL = ResourceUtils.getURL("classpath:xsd/geodesyml-0.2.0/catalog.xml");
             catalogPath = catalogURL.getPath();
         } catch (IOException e) {
             logger.error("Failed to find the catalog.xml file on the classpath. Check the package structure.", e);

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>au.gov.ga.geodesy.gws</groupId>
     <artifactId>gws</artifactId>
     <packaging>pom</packaging>
-    <version>0.2.1</version>
+    <version>0.2.2</version>
     <name>Geodesy Web Services Aggregate</name>
     <url>https://github.com/GeoscienceAustralia/Geodesy-Web-Services</url>
     <description>Geodesy Web Services</description>
@@ -17,7 +17,7 @@
     <parent>
         <groupId>au.gov.ga.geodesy.gws</groupId>
         <artifactId>gws-parent</artifactId>
-        <version>0.2.1</version>
+        <version>0.2.2</version>
         <relativePath>gws-parent</relativePath>
     </parent>
     <modules>

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -10,7 +10,7 @@ sudo rm -f /etc/mavenrc
 
 mvn --settings ./travis/maven-settings.xml -U install -DskipTests > /dev/null
 
-#if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
     mvn --settings ./travis/maven-settings.xml deploy -pl '!gws-system-test' -DredirectTestOutputToFile
     mvn --settings ./travis/maven-settings.xml deploy -pl gws-system-test -DskipTests
     mvn --settings ./travis/maven-settings.xml site -DskipTests -pl gws-core
@@ -28,3 +28,6 @@ mvn --settings ./travis/maven-settings.xml -U install -DskipTests > /dev/null
     mvn --settings ./travis/maven-settings.xml site-deploy -DskipTests -pl gws-core
     ./aws/codedeploy-WebServices/deploy.sh dev
     ./aws/codedeploy-GeoServer/deploy.sh dev
+else
+    mvn --settings ./travis/maven-settings.xml verify -pl '!gws-system-test' -DredirectTestOutputToFile
+fi


### PR DESCRIPTION
New release of GWS, which grabs the now released dependencies at version 0.2.0 (using GeodesyML 0.4) and 0.3.0 of igssitelog-java-bindings, which does not depend on GeodesyML.