### PR TITLE
Increase testng verbosity

### DIFF
--- a/gws-system-test/src/main/resources/testng.xml
+++ b/gws-system-test/src/main/resources/testng.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
-<suite name="SystemTestSuite" verbose="1">
+<suite name="SystemTestSuite" verbose="2">
     <test name="Test">
         <classes>
             <class name="au.gov.ga.geodesy.gws.systemtest.AwsSystemTest"/>


### PR DESCRIPTION
Currently system tests are failling with

LifecycleEvent - ValidateService
Script - validate-service.sh
[stderr][TestNG] [ERROR]
[stderr]Cannot instantiate class au.gov.ga.geodesy.gws.systemtest.UploadSiteLogsSystemTest

This change should give us more information about the failure