### PR TITLE
Exclude transitive spring dependency

### DIFF
--- a/gws-parent/pom.xml
+++ b/gws-parent/pom.xml
@@ -76,6 +76,12 @@
                 <groupId>au.gov.ga.gnss</groupId>
                 <artifactId>gnss-support-rinex</artifactId>
                 <version>1.0.1-SNAPSHOT</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-beans</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
We are at spring 4.3.6.RELEASE, but gnss-support-rinex.jar is bringing in a
later version, which may be causing the following intermittent system
test failure:

```
...
[stdout] at org.springframework.test.context.BootstrapUtils.createCacheAwareContextLoaderDelegate(BootstrapUtils.java:98)
[stdout] ... 28 more
[stdout]Caused by: java.lang.NoClassDefFoundError: org/springframework/core/KotlinDetector
[stdout] at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:187)
[stdout] at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:138)
[stdout] ... 30 more
[stdout]Caused by: java.lang.ClassNotFoundException: org.springframework.core.KotlinDetector
[stdout] at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
[stdout] at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
[stdout] at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
[stdout] at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
```