### PR TITLE
Truncate Agency Name in Skeleton Endpoint

### DIFF
--- a/gws-core/src/main/java/au/gov/ga/geodesy/port/adapter/rest/SkeletonEndpoint.java
+++ b/gws-core/src/main/java/au/gov/ga/geodesy/port/adapter/rest/SkeletonEndpoint.java
@@ -10,7 +10,6 @@ import com.vividsolutions.jts.geom.Point;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.hateoas.config.EnableEntityLinks;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -57,8 +56,14 @@ public class SkeletonEndpoint {
 
         List<SiteResponsibleParty> custodian = siteLog.getSiteMetadataCustodians();
         if (!custodian.isEmpty()) {
-            rinexFileHeader.setAgency(
-                custodian.get(0).getParty().getOrganisationName().toString());
+            String agency = custodian.get(0).getParty().getOrganisationName().toString();
+            // Truncate Organisation name if longer than 40 chars
+            // TODO: Add Header comment containing untruncated Organisation Name
+            // TODO: Consider doing this in RinexFileHeader class
+            if (agency.length() > 40) {
+                agency = agency.substring(0, 36) + "...";
+            }
+            rinexFileHeader.setAgency(agency);
         }
 
         List<GnssReceiverLogItem> receiverLogItemList = new ArrayList<>(siteLog.getGnssReceivers());

--- a/gws-core/src/test/java/au/gov/ga/geodesy/port/adapter/rest/SkeletonEndpointITest.java
+++ b/gws-core/src/test/java/au/gov/ga/geodesy/port/adapter/rest/SkeletonEndpointITest.java
@@ -11,13 +11,22 @@ import org.springframework.test.annotation.Rollback;
 import org.testng.annotations.Test;
 
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertTrue;
 
 public class SkeletonEndpointITest extends IntegrationTest {
 
     @Autowired
     private CorsSiteLogService siteLogService;
+
+    private String alicSkeleton =
+        "ALIC                                                        MARKER NAME\n" +
+        "50137M001                                                   MARKER NUMBER\n" +
+        "                    Geoscience Australia                    OBSERVER / AGENCY\n" +
+        "1830439             LEICA GR25          4.31.101            REC # / TYPE / VERS\n" +
+        "09370001            LEIAR25.R3      NONE                    ANT # / TYPE\n" +
+        " -4052051.7670  4212836.2150 -2545106.0270                  APPROX POSITION XYZ\n" +
+        "        0.0015        0.0000        0.0000                  ANTENNA: DELTA H/E/N\n" +
+        "                                                            END OF HEADER\n";
 
     @Test
     @Rollback(false)
@@ -38,8 +47,7 @@ public class SkeletonEndpointITest extends IntegrationTest {
             .contentType("text/plain")
             .extract().body().asString();
 
-        assertThat(text, containsString("ANTENNA: DELTA"));
-        assertThat(text, containsString("50137M001"));
+        assertTrue(text.equals(alicSkeleton));
     }
 
     @Test(dependsOnMethods = {"upload"})
@@ -54,8 +62,7 @@ public class SkeletonEndpointITest extends IntegrationTest {
             .contentType("text/plain")
             .extract().body().asString();
 
-        assertThat(text, containsString("AGENCY"));
-        assertThat(text, containsString("50137M001"));
+        assertTrue(text.equals(alicSkeleton));
     }
 
     @Test

--- a/gws-core/src/test/java/au/gov/ga/geodesy/port/adapter/rest/SkeletonEndpointITest.java
+++ b/gws-core/src/test/java/au/gov/ga/geodesy/port/adapter/rest/SkeletonEndpointITest.java
@@ -21,10 +21,10 @@ public class SkeletonEndpointITest extends IntegrationTest {
     private String alicSkeleton =
         "ALIC                                                        MARKER NAME\n" +
         "50137M001                                                   MARKER NUMBER\n" +
-        "                    Geoscience Australia                    OBSERVER / AGENCY\n" +
-        "1830439             LEICA GR25          4.31.101            REC # / TYPE / VERS\n" +
+        "                    Geoscience Australia - Longer than 4... OBSERVER / AGENCY\n" +
+        "1830439             LEICA GR25          4.11.606/6.523      REC # / TYPE / VERS\n" +
         "09370001            LEIAR25.R3      NONE                    ANT # / TYPE\n" +
-        " -4052051.7670  4212836.2150 -2545106.0270                  APPROX POSITION XYZ\n" +
+        " -4130636.5890  2894953.1210 -3890530.4420                  APPROX POSITION XYZ\n" +
         "        0.0015        0.0000        0.0000                  ANTENNA: DELTA H/E/N\n" +
         "                                                            END OF HEADER\n";
 

--- a/gws-core/src/test/resources/sitelog/geodesyml/custom/ALIC.xml
+++ b/gws-core/src/test/resources/sitelog/geodesyml/custom/ALIC.xml
@@ -646,7 +646,7 @@ AUSTRALIA</gco:CharacterString>
                     <gco:CharacterString>Site Metadata Custodian</gco:CharacterString>
                 </gmd:individualName>
                 <gmd:organisationName>
-                    <gco:CharacterString>Geoscience Australia</gco:CharacterString>
+                    <gco:CharacterString>Geoscience Australia - Longer than 40 characters</gco:CharacterString>
                 </gmd:organisationName>
                 <gmd:contactInfo>
                     <gmd:CI_Contact>


### PR DESCRIPTION
Also updated tests to compare the entire response body to the expected skeleton file content.