### PR TITLE
Add aws_s3_bucket resource address to terraform target flag

### DIFF
--- a/aws/deploy-local.sh
+++ b/aws/deploy-local.sh
@@ -42,7 +42,7 @@ EOF
 
 terraform init
 terraform workspace select $environment || terraform workspace new $environment
-terraform apply -auto-approve -input=false
+terraform apply -auto-approve -input=false -target aws_s3_bucket.gnss_metadata_document_storage
 
 function onExit {
     rm -f main_override.tf


### PR DESCRIPTION
When running `./aws/deploy-local.sh` in LocalStack, an IAM role and policy `arn:aws:iam::688660191997:role/gnss-metadata-document-storage-local-access` will be created in geodesy-operations account, which will cause error in next run. It seems that LocalStack does not support testing of security configuration, IAM policies, etc. So, add terraform target flag to s3 bucket to skip the creation of IAM role/policy.