### PR TITLE
Add bucket policy to allow cross account access to document storage

### DIFF
--- a/aws/terraform/document_storage.tf
+++ b/aws/terraform/document_storage.tf
@@ -10,6 +10,33 @@ resource "aws_s3_bucket" "gnss_metadata_document_storage" {
   }
 }
 
+resource "aws_s3_bucket_policy" "document_storage" {
+  bucket = aws_s3_bucket.gnss_metadata_document_storage.id
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:DeleteObject",
+        "s3:PutObject",
+        "s3:PutObjectAcl"
+      ],
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "094928090547"
+      },
+      "Resource": [
+        "${aws_s3_bucket.gnss_metadata_document_storage.arn}",
+        "${aws_s3_bucket.gnss_metadata_document_storage.arn}/*"
+      ]
+    }
+  ]
+}
+POLICY
+}
+
 output "gnss_metadata_document_storage_bucket" {
   value = aws_s3_bucket.gnss_metadata_document_storage.bucket
 }


### PR DESCRIPTION
Currently when uploading images to the document storage bucket,  I still got error messages: 
`Access Denied (Service: Amazon S3; Status Code: 403; Error Code: AccessDenied; Request ID: 27C65B9719E2A5C4)`.
With this bucket policy deployed as testing, I successfully uploaded and deleted images to/from the bucket for ALIC sitelog.